### PR TITLE
Adjust Trove classifier to `Development Status :: 2 - Pre-Alpha`

### DIFF
--- a/platforms/wheel_tags.bzl
+++ b/platforms/wheel_tags.bzl
@@ -27,7 +27,7 @@ trove_classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Topic :: Desktop Environment :: Gnome",
-    "Development Status :: 1 - Planning",
+    "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: C++",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
<!-- What issue does this PR solve -->
<!-- Please link the corresponding issue with keywords like `Closes #123` -->
Part of #70 

### Description
<!-- What does this PR do? -->
Since we are preparing for the first alpha version, we should tag all the current artifacts we produce as `Development Status :: 2 - Pre-Alpha`

### Testing
<!-- How can reviewers test this change? -->

### Notes
<!-- What are some additional contexts that will help reviewers to review? -->
<!-- What are some technical details that the reviewers should know.  -->
<!-- What are some items that you want to discuss with the rest of the team -->