### PR TITLE
Construct `VirtualWidget`s without Copy Construction

### DIFF
--- a/include/vwidget/numeric_value_widget.h
+++ b/include/vwidget/numeric_value_widget.h
@@ -55,5 +55,5 @@ class NumericValueWidget : public VirtualWidget {
   int max_value_ = -1;
 
  protected:
-  explicit NumericValueWidget(const std::string& widget_name);
+  explicit NumericValueWidget(std::string&& widget_name);
 };

--- a/include/vwidget/virtual_widget.h
+++ b/include/vwidget/virtual_widget.h
@@ -5,7 +5,14 @@
 #include <vector>
 
 class VirtualWidget {
+ protected:
+  explicit VirtualWidget(std::string&& widget_name);
+
  public:
+  virtual ~VirtualWidget() = default;
+  VirtualWidget(const VirtualWidget& other) = delete;
+  VirtualWidget& operator=(const VirtualWidget& other) = delete;
+
   //  Getters
   /**
    * Get title text
@@ -206,8 +213,6 @@ class VirtualWidget {
    */
   virtual std::string ToString() const;
 
-  virtual ~VirtualWidget() = default;
-
  private:
   std::string title_text_;
   std::string help_text_;
@@ -221,7 +226,4 @@ class VirtualWidget {
   bool is_focused_ = false;
   std::weak_ptr<VirtualWidget> parent_;
   std::vector<std::shared_ptr<VirtualWidget>> children_;
-
- protected:
-  explicit VirtualWidget(std::string widget_name);
 };

--- a/include/vwidget/widgets/virtual_text_widget.h
+++ b/include/vwidget/widgets/virtual_text_widget.h
@@ -6,7 +6,7 @@
 class VirtualTextWidget : public VirtualWidget {
  public:
   VirtualTextWidget();
-  explicit VirtualTextWidget(std::string widget_name);
+  explicit VirtualTextWidget(std::string&& widget_name);
   ~VirtualTextWidget() override = default;
 
   /**

--- a/src/native/win/vwidget_generator_win.cpp
+++ b/src/native/win/vwidget_generator_win.cpp
@@ -13,14 +13,16 @@ std::shared_ptr<VirtualWidget> GenerateVWidgetTree(IUIAutomationElement* root_el
   std::queue<std::pair<std::shared_ptr<VirtualWidget>, IUIAutomationElement*>> queue;
   queue.emplace(root, root_element);
   HRESULT hresult = S_OK;
+  IUIAutomationElement* current_element = nullptr;
   while (!queue.empty()) {
     // This is the first child of the clade
     auto [parent_vwidget, curr] = queue.front();
     queue.pop();
 
     std::shared_ptr<VirtualWidget> curr_vwidget = nullptr;
-    IUIAutomationElement* current_element = curr;
     IUIAutomationElement* first_child_element = nullptr;
+    current_element = curr;
+
     while (current_element) {
       // Check next sibling, add their first child to queue and bind
       // parent/child

--- a/src/vwidget/numeric_value_widget.cpp
+++ b/src/vwidget/numeric_value_widget.cpp
@@ -1,5 +1,5 @@
 #include "include/vwidget/numeric_value_widget.h"
 #include "include/vwidget/virtual_widget.h"
 
-NumericValueWidget::NumericValueWidget(const std::string& widget_name)
-    : VirtualWidget(widget_name) {}
+NumericValueWidget::NumericValueWidget(std::string&& widget_name)
+    : VirtualWidget(std::move(widget_name)) {}

--- a/src/vwidget/virtual_widget.cpp
+++ b/src/vwidget/virtual_widget.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <utility>
 
-VirtualWidget::VirtualWidget(std::string widget_name) : widget_name_(std::move(widget_name)) {}
+VirtualWidget::VirtualWidget(std::string&& widget_name) : widget_name_(std::move(widget_name)) {}
 
 void VirtualWidget::AddChild(const std::shared_ptr<VirtualWidget>& child) {
   children_.emplace_back(child);

--- a/src/vwidget/widgets/virtual_text_widget.cpp
+++ b/src/vwidget/widgets/virtual_text_widget.cpp
@@ -4,7 +4,7 @@
 #include "include/vwidget/widgets/virtual_text_widget.h"
 
 VirtualTextWidget::VirtualTextWidget() : VirtualWidget("VirtualTextWidget") {}
-VirtualTextWidget::VirtualTextWidget(std::string widget_name)
+VirtualTextWidget::VirtualTextWidget(std::string&& widget_name)
     : VirtualWidget(std::move(widget_name)) {}
 
 std::string VirtualTextWidget::ToString() const {


### PR DESCRIPTION
<!-- What issue does this PR solve -->
<!-- Please link the corresponding issue with keywords like `Closes #123` -->
Closes #74 

### Description
<!-- What does this PR do? -->

This PR introduces some minor optimizations involving copy/move operations. It also introduces a guard against future mis-copying.

### Testing
<!-- How can reviewers test this change? -->

- Ensure everything works & compiles as normal on Mac and Linux.

### Notes
<!-- What are some additional contexts that will help reviewers to review? -->
<!-- What are some technical details that the reviewers should know.  -->
<!-- What are some items that you want to discuss with the rest of the team -->

For context: `&&` was introduced in C++11, which allows for rvalue references to be passed via function parameters. This allows us to re-allocate temporary values without destruction or construction, such as in the case of all our vwidget constructors. 