### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
<!-- What issue does this PR solve -->
<!-- Please link the corresponding issue with keywords like `Closes #123` -->

Part of #15, #35

### Description
<!-- What does this PR do? -->
To integrate with ReadTheDocs and host our documentation, it requires us to have a configuration file at the root of the project. Following their official [documentation](https://docs.readthedocs.com/platform/stable/tutorial/index.html), this PR adds`.readthedocs.yml` to unblock us.

### Testing
<!-- How can reviewers test this change? -->
Not testable at the moment.

### Notes
<!-- What are some additional contexts that will help reviewers to review? -->
<!-- What are some technical details that the reviewers should know.  -->
<!-- What are some items that you want to discuss with the rest of the team -->
This won't interfere with the existing documentation generation flow. This PR just added the necessary RTD configuration file that RTD required before we can proceed with further documentation generation and hosting.

https://docs.readthedocs.com/platform/stable/tutorial/index.html