### PR TITLE
Update GitHub repository URLs to new organization

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,7 +42,7 @@ py_wheel(
     description_content_type = "text/markdown; charset=UTF-8; variant=GFM",
     description_file = ":readme",
     distribution = project_name,
-    homepage = "https://github.com/Lmh-java/PyScreenReader",
+    homepage = "https://github.com/PyScreenReader/PyScreenReader",
     license = "MIT",
     platform = platform_tag,
     python_tag = python_tag,

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ Feedback is a gift! We appreciate any kind of feedback/questions/concerns in the
   next version of PyScreenReader.
 - Found Security concerns and vulnerabilities? Oh no, now we have trouble! But the good news is you found it and
   alerted us, so nothing bad will happen. Please refer to our [SECURITY](SECURITY.md) page and report them through
-  the [GitHub Security Portal](https://github.com/Lmh-java/PyScreenReader/security).
+  the [GitHub Security Portal](https://github.com/PyScreenReader/PyScreenReader/security).
 
 ## Licensing
 
 PyScreenReader is licensed under [MIT License](LICENSE).
 By using, distributing, or contributing to this project, you agree the terms and conditions of this license.
 
-PyScreenReader uses libraries:
+PyScreenReader greatly relies on:
 
 - [Google Test](https://github.com/google/googletest)
 - [PyBind11](https://github.com/pybind/pybind11)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ The PyScreenReader team and community take security issues seriously. We appreci
 
 ## Reporting a Vulnerability
 
-To report a security issue, please use the GitHub Security Advisory **["Report a Vulnerability"](https://github.com/Lmh-java/PyScreenReader/security)** tab. This is the only accepted channel for vulnerability reports. Please do **not** disclose issues in public issues, pull requests, or discussions.
+To report a security issue, please use the GitHub Security Advisory **["Report a Vulnerability"](https://github.com/PyScreenReader/PyScreenReader/security)** tab. This is the only accepted channel for vulnerability reports. Please do **not** disclose issues in public issues, pull requests, or discussions.
 
 
 ## Our Response

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -74,8 +74,9 @@ Currently, only PyPi installation via `pip` is supported.
 Useful Links
 ------------
 
-* `GitHub Repository <https://github.com/Lmh-java/PyScreenReader>`_
-* `Issue Tracker <https://github.com/Lmh-java/PyScreenReader/issues>`_
+* `GitHub Repository <https://github.com/PyScreenReader/PyScreenReader>`_
+* `Issue Tracker <https://github.com/PyScreenReader/PyScreenReader/issues>`_
+* `Documentation <https://pyscreenreader.readthedocs.io/en/latest>`_
 * `PyPI Project <https://pypi.org/project/PyScreenReader/>`_
 
 .. toctree::

--- a/doc/source/quickstart.md
+++ b/doc/source/quickstart.md
@@ -31,7 +31,7 @@ children = root.get_children()
 Virtual widgets (such as VirtualButtonWidget, etc.) are high-level abstractions of native system UI elements.
 They are organized into a hierarchical structure — a virtual widget tree — where each node represents a single widget on the screen.
 
-In the example above, the `root` variable refers to the root node of the widget tree of program with PID "424242".  
+In the example above, the `root` variable refers to the root node of the widget tree of program with PID 20880.  
 From there, you can navigate through its children and inspect each widget's properties, including:
 - Control type
 - Bounding rectangle

--- a/doc/source/quickstart.md
+++ b/doc/source/quickstart.md
@@ -7,17 +7,25 @@ pip install PyScreenReader
 ```
 > **PyScreenReader is still in active development.**  
 > If installation via `pip` fails, it may be due to incompatibility with your system’s OS, architecture, or Python interpreter version.
-> Please kindly help us to file a report [here](https://github.com/Lmh-java/PyScreenReader/issues).
+> Please kindly help us to file a report [here](https://github.com/PyScreenReader/PyScreenReader/issues).
 
 ## Example
 In your Python script,
-```python
-from PyScreenReader import ScreenReader
+```py
+# Import the reader itself
+from PyScreenReader.screen_reader import ScreenReader
+# Import the widgets the reader will return
+from PyScreenReader.virtual_widgets import VirtualWidget
 
 # Create a screen reader instance
 screen_reader = ScreenReader()
-# Read the virtual widget tree by program's PID
-root = screen_reader.get_virtual_widget_tree_by_pid("424242")
+# Read the virtual widget tree by your program's PID
+root = screen_reader.get_virtual_widget_tree_by_pid(20880)
+# Print the location of the root widget extracted
+print(f"Position of Root Widget (X: {root.get_x()}, Y: {root.get_y()})")
+
+# Optional: Get all children of the root as a list of VirtualWidgets to traverse the tree!
+children = root.get_children()
 ```
 
 Virtual widgets (such as VirtualButtonWidget, etc.) are high-level abstractions of native system UI elements.


### PR DESCRIPTION
Closes #81 

### Description
Update GitHub repository URL from `Lmh-java/PyScreenReader` to `PyScreenReader/PyScreenReader` across all project files. This includes updates to:

- BUILD file homepage reference
- README.md security reporting links
- SECURITY.md vulnerability reporting URL
- Documentation links in index.rst
- Issue tracker links in quickstart.md

Also improved the Python example in quickstart.md with more detailed import statements and added code to demonstrate widget position access.

### Testing
Verify all links point to the new repository URL by clicking through them. Test the updated code example to ensure it works as expected.

### Notes
The README.md description of libraries was also updated from "PyScreenReader uses libraries" to "PyScreenReader greatly relies on".