### PR TITLE
Refactor GetAXUIElementRefByPID to accept pid_t instead of string

### DIFF
--- a/tests/cpp/native/macos/utils/test_system_utils.cpp
+++ b/tests/cpp/native/macos/utils/test_system_utils.cpp
@@ -10,7 +10,6 @@ TEST(SystemUtilsTest, ValidPIDReturnsAXUIElementRef) {
   CFRelease(element);
 }
 
-
 TEST(SystemUtilsTest, NonExistentPIDStillReturnsNonNullElement) {
   // AXUIElementCreateApplication still returns a valid ref even for dead PIDs
   pid_t fake_pid = 999999;


### PR DESCRIPTION
### Description
Updated `GetAXUIElementRefByPID` function to accept a `pid_t` parameter instead of a string. This change simplifies the API by using the native process ID type directly rather than converting between string and numeric representations.

The PR also removes the test case for invalid PID strings since it's no longer applicable with the new parameter type.

### Testing
Run the updated tests to verify that the function works correctly with the new parameter type. The existing tests have been modified to pass `pid_t` values directly.

### Notes
This change improves type safety by using the appropriate system type for process IDs rather than string representations.