### PR TITLE
Add file change detection to skip CI jobs when code is unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect file changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.py'
+              - 'requirements-dev.txt'
+              - '**/*.h'
+              - '**/*.cpp'
+              - '**/*.bzl'
+              - '**/*.bazel'
+              - '**/BUILD'
+
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.platform.os }}
     name: ${{ matrix.platform.os }}-test
     strategy:
@@ -46,8 +69,9 @@ jobs:
         run: bazel build ${{ matrix.platform.build_targets }}
 
   lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      python: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +38,10 @@ jobs:
               - '**/*.bzl'
               - '**/*.bazel'
               - '**/BUILD'
+              - '.github/**/*.yml'
+              - '**/requirements.in'
+              - '**/requirements_lock.txt'
+              - '**/requirements_lock_win.txt'
 
   test:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 # PyScreenReader
 
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/PyScreenReader/PyScreenReader/build.yml)
+![GitHub branch check runs](https://img.shields.io/github/check-runs/PyScreenReader/PyScreenReader/main)
+![Read the Docs (version)](https://img.shields.io/readthedocs/pyscreenreader/latest)
+![GitHub License](https://img.shields.io/github/license/PyScreenReader/PyScreenReader)
+![GitHub Repo stars](https://img.shields.io/github/stars/PyScreenReader/PyScreenReader)
+![GitHub Release](https://img.shields.io/github/v/release/PyScreenReader/PyScreenReader)
+
+[//]: # (TODO: add PyPi flag)
+
+
 PyScreenReader is a library for developers to parse **on-screen** information using the simplicity of **Python**.
 
 It's a cross-platform abstraction of native accessibility APIs for Windows, macOS, and Linux, based around

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![Read the Docs (version)](https://img.shields.io/readthedocs/pyscreenreader/latest)
 ![GitHub License](https://img.shields.io/github/license/PyScreenReader/PyScreenReader)
 ![GitHub Repo stars](https://img.shields.io/github/stars/PyScreenReader/PyScreenReader)
+
 ![GitHub Release](https://img.shields.io/github/v/release/PyScreenReader/PyScreenReader)
 
 [//]: # (TODO: add PyPi flag)


### PR DESCRIPTION
### Description
This PR optimizes the CI workflow by adding a file change detection step. It creates a new `changes` job that checks for modifications in Python, C++, and Bazel files. The existing `test` and `lint` jobs now only run when relevant code files have been changed, as they depend on the output from the `changes` job.

### Testing
The changes can be tested by creating PRs with different file modifications and observing that the CI workflow only runs the test and lint jobs when code files are changed.

### Notes
The file patterns being monitored include:
- Python files (*.py)
- Development requirements (requirements-dev.txt)
- C++ header and source files (*.h, *.cpp)
- Bazel configuration files (*.bzl, *.bazel, BUILD)